### PR TITLE
Activate immediate exit (fixes error not exiting)

### DIFF
--- a/gi.sh
+++ b/gi.sh
@@ -18,6 +18,9 @@
 # along with CScout.  If not, see <http://www.gnu.org/licenses/>.
 #
 
+# Activate immediate exit
+set -e
+
 # Display system usage and exit
 usage()
 {


### PR DESCRIPTION
I am not sure if this solution is appreciated (so please reject if you do not like the use of set), but otherwise the control flow control flow in `error` continues after the exit call, which is a bug IMHO.