### PR TITLE
Corrected usage text for watcher.

### DIFF
--- a/gi.sh
+++ b/gi.sh
@@ -435,7 +435,7 @@ sub_tag()
 usage_watcher()
 {
   cat <<\USAGE_watcher_EOF
-gi tag usage: gi watcher [-r] <sha> <tag> ...
+gi watcher usage: gi watcher [-r] <sha> <tag> ...
 -r	Remove the specified watcher
 USAGE_watcher_EOF
   exit 2


### PR DESCRIPTION
The usage text for the watcher command said "tag" rather than "watcher" in the usage example.