### PR TITLE
Fix fallback identifier resolution command.

### DIFF
--- a/gi.sh
+++ b/gi.sh
@@ -57,7 +57,7 @@ error()
 filesysid()
 {
   stat --printf='%d:%i' "$1" 2>/dev/null ||
-    stat -f '%d:%i' "$1"
+    stat -f --printf='%d:%i' "$1"
 }
 
 # Move to the .issues directory


### PR DESCRIPTION
Unless I'm missing something, the current implementation would fail when dealing with the **file system status** instead of **file status** because the format would be taken as the file name argument here:
```
stat -f '%d:%i' "$1"
```
